### PR TITLE
Resolve 3 mismatch stubbings PathBasedServletAcceptorTest.java

### DIFF
--- a/src/test/java/org/apache/sling/servlets/resolver/internal/PathBasedServletAcceptorTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/PathBasedServletAcceptorTest.java
@@ -64,7 +64,7 @@ public class PathBasedServletAcceptorTest {
             return this;
         }
 
-        TestCase withServiceProperty(String key, Object ... values) {
+        TestCase withServiceProperty(String key, Object... values) {
             serviceProperties.put(key, values);
             return this;
         }
@@ -79,7 +79,7 @@ public class PathBasedServletAcceptorTest {
             return this;
         }
 
-        TestCase withSelectors(String ... sels) {
+        TestCase withSelectors(String... sels) {
             selectors.addAll(Arrays.asList(sels));
             return this;
         }
@@ -92,11 +92,10 @@ public class PathBasedServletAcceptorTest {
         void assertAccept(boolean expected) {
 
             // Stub the ServiceReference with our service properties
-            @SuppressWarnings("unchecked")
-            final ServiceReference<Servlet> reference = mock(ServiceReference.class);
-            final String [] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
+            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
+            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
             when(reference.getPropertyKeys()).thenReturn(keys);
-            for(String key: keys) {
+            for (String key : keys) {
                 when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
             }
 
@@ -120,191 +119,391 @@ public class PathBasedServletAcceptorTest {
             assertEquals(expected, actual);
         }
 
+        void assertAccept2(boolean expected) {
+
+            // Stub the ServiceReference with our service properties
+            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
+            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
+            when(reference.getPropertyKeys()).thenReturn(keys);
+            for (String key : keys) {
+                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
+            }
+
+            when(reference.getProperty("sling.servlet.methods")).thenReturn(null);
+
+            // Wire the Servlet to our ServiceReference
+            final ServletContext sc = mock(ServletContext.class);
+            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
+            final Servlet servlet = mock(Servlet.class);
+            when(servlet.getServletConfig()).thenReturn(ssc);
+
+            // Setup the request values
+            final RequestPathInfo rpi = mock(RequestPathInfo.class);
+            when(rpi.getExtension()).thenReturn(extension);
+            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
+
+            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
+            when(request.getRequestPathInfo()).thenReturn(rpi);
+            when(request.getMethod()).thenReturn(method);
+
+            // And call the acceptor
+            final boolean actual = acceptor.accept(request, servlet);
+            assertEquals(expected, actual);
+        }
+
+
+        void assertAccept3(boolean expected) {
+
+            // Stub the ServiceReference with our service properties
+            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
+            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
+            when(reference.getPropertyKeys()).thenReturn(keys);
+            for (String key : keys) {
+                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
+            }
+
+            when(reference.getProperty("sling.servlet.extensions")).thenReturn(null);
+            when(reference.getProperty("sling.servlet.selectors")).thenReturn(null);
+            when(reference.getProperty("sling.servlet.methods")).thenReturn(null);
+
+
+            // Wire the Servlet to our ServiceReference
+            final ServletContext sc = mock(ServletContext.class);
+            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
+            final Servlet servlet = mock(Servlet.class);
+            when(servlet.getServletConfig()).thenReturn(ssc);
+
+            // Setup the request values
+            final RequestPathInfo rpi = mock(RequestPathInfo.class);
+            when(rpi.getExtension()).thenReturn(extension);
+            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
+
+            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
+            when(request.getRequestPathInfo()).thenReturn(rpi);
+            when(request.getMethod()).thenReturn(method);
+
+            // And call the acceptor
+            final boolean actual = acceptor.accept(request, servlet);
+            assertEquals(expected, actual);
+        }
+
+        void assertAccept4(boolean expected) {
+
+            // Stub the ServiceReference with our service properties
+            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
+            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
+            when(reference.getPropertyKeys()).thenReturn(keys);
+            for (String key : keys) {
+                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
+            }
+
+            when(reference.getProperty("sling.servlet.extensions")).thenReturn(null);
+            when(reference.getProperty("sling.servlet.methods")).thenReturn(null);
+
+
+            // Wire the Servlet to our ServiceReference
+            final ServletContext sc = mock(ServletContext.class);
+            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
+            final Servlet servlet = mock(Servlet.class);
+            when(servlet.getServletConfig()).thenReturn(ssc);
+
+            // Setup the request values
+            final RequestPathInfo rpi = mock(RequestPathInfo.class);
+            when(rpi.getExtension()).thenReturn(extension);
+            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
+
+            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
+            when(request.getRequestPathInfo()).thenReturn(rpi);
+            when(request.getMethod()).thenReturn(method);
+
+            // And call the acceptor
+            final boolean actual = acceptor.accept(request, servlet);
+            assertEquals(expected, actual);
+        }
+
+        void assertAccept5(boolean expected) {
+
+            // Stub the ServiceReference with our service properties
+            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
+            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
+            when(reference.getPropertyKeys()).thenReturn(keys);
+            for (String key : keys) {
+                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
+            }
+
+            when(reference.getProperty("sling.servlet.extensions")).thenReturn(null);
+            when(reference.getProperty("sling.servlet.selectors")).thenReturn(null);
+
+            // Wire the Servlet to our ServiceReference
+            final ServletContext sc = mock(ServletContext.class);
+            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
+            final Servlet servlet = mock(Servlet.class);
+            when(servlet.getServletConfig()).thenReturn(ssc);
+
+            // Setup the request values
+            final RequestPathInfo rpi = mock(RequestPathInfo.class);
+            when(rpi.getExtension()).thenReturn(extension);
+            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
+
+            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
+            when(request.getRequestPathInfo()).thenReturn(rpi);
+            when(request.getMethod()).thenReturn(method);
+
+            // And call the acceptor
+            final boolean actual = acceptor.accept(request, servlet);
+            assertEquals(expected, actual);
+        }
+
+        void assertAccept6(boolean expected) {
+
+            // Stub the ServiceReference with our service properties
+            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
+            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
+            when(reference.getPropertyKeys()).thenReturn(keys);
+            for (String key : keys) {
+                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
+            }
+
+            when(reference.getProperty("sling.servlet.selectors")).thenReturn(null);
+            when(reference.getProperty("sling.servlet.methods")).thenReturn(null);
+
+
+            // Wire the Servlet to our ServiceReference
+            final ServletContext sc = mock(ServletContext.class);
+            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
+            final Servlet servlet = mock(Servlet.class);
+            when(servlet.getServletConfig()).thenReturn(ssc);
+
+            // Setup the request values
+            final RequestPathInfo rpi = mock(RequestPathInfo.class);
+            when(rpi.getExtension()).thenReturn(extension);
+            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
+
+            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
+            when(request.getRequestPathInfo()).thenReturn(rpi);
+            when(request.getMethod()).thenReturn(method);
+
+            // And call the acceptor
+            final boolean actual = acceptor.accept(request, servlet);
+            assertEquals(expected, actual);
+        }
+
+        void assertAccept7(boolean expected) {
+
+            // Stub the ServiceReference with our service properties
+            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
+            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
+            when(reference.getPropertyKeys()).thenReturn(keys);
+            for (String key : keys) {
+                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
+            }
+
+            when(reference.getProperty("sling.servlet.extensions")).thenReturn(null);
+
+            // Wire the Servlet to our ServiceReference
+            final ServletContext sc = mock(ServletContext.class);
+            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
+            final Servlet servlet = mock(Servlet.class);
+            when(servlet.getServletConfig()).thenReturn(ssc);
+
+            // Setup the request values
+            final RequestPathInfo rpi = mock(RequestPathInfo.class);
+            when(rpi.getExtension()).thenReturn(extension);
+            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
+
+            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
+            when(request.getRequestPathInfo()).thenReturn(rpi);
+            when(request.getMethod()).thenReturn(method);
+
+            // And call the acceptor
+            final boolean actual = acceptor.accept(request, servlet);
+            assertEquals(expected, actual);
+        }
     }
 
     @Test
     public void extensionNoMatch() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, "sp")
-        .withExtension("somethingElse")
-        .assertAccept(false);
+                .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, "sp")
+                .withExtension("somethingElse")
+                .assertAccept(false);
     }
 
     @Test
     public void extensionNone() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, "sp")
-        .assertAccept(false);
+                .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, "sp")
+                .assertAccept(false);
     }
 
     @Test
     public void extensionNoMatchInN() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, "one", "two")
-        .withExtension("somethingElse")
-        .assertAccept(false);
+                .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, "one", "two")
+                .withExtension("somethingElse")
+                .assertAccept(false);
     }
 
     @Test
     public void extensionMatchOneInN() {
         new TestCase()
-        // test various ways of setting multiple properties
-        .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, (Object)new String[] { "one", "two" })
-        .withExtension("one")
-        .assertAccept(true);
+                // test various ways of setting multiple properties
+                .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, (Object) new String[]{"one", "two"})
+                .withExtension("one")
+                .assertAccept6(true);
     }
 
     @Test
     public void extensionPropertyNotSet() {
         new TestCase()
-        .withExtension("somethingElse")
-        .assertAccept(true);
+                .withExtension("somethingElse")
+                .assertAccept3(true);
     }
 
     @Test
     public void selectorNoMatch() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "sel")
-        .withSelector("somethingElse")
-        .assertAccept(false);
+                .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "sel")
+                .withSelector("somethingElse")
+                .assertAccept(false);
     }
 
     @Test
     public void selectorOneMatchesOne() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "sel")
-        .withSelector("sel")
-        .assertAccept(true);
+                .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "sel")
+                .withSelector("sel")
+                .assertAccept4(true);
     }
 
     @Test
     public void selectorOneFromNInN() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "one", "two", "three")
-        .withSelectors("three", "and", "somethingElse")
-        .assertAccept(true);
+                .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "one", "two", "three")
+                .withSelectors("three", "and", "somethingElse")
+                .assertAccept4(true);
     }
 
     @Test
     public void selectorZeroInN() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "one", "two", "three")
-        .withExtension("three")
-        .assertAccept(false);
+                .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "one", "two", "three")
+                .withExtension("three")
+                .assertAccept7(false);
     }
 
     @Test
     public void selectorOneInN() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "one", "two", "42")
-        .withSelectors("42")
-        .assertAccept(true);
+                .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "one", "two", "42")
+                .withSelectors("42")
+                .assertAccept4(true);
     }
 
     @Test
     public void selectorPropertyNotSet() {
         new TestCase()
-        .withSelector("somethingElse")
-        .assertAccept(true);
+                .withSelector("somethingElse")
+                .assertAccept3(true);
     }
 
     @Test
     public void methodNoMatch() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_METHODS, "meth")
-        .withMethod("somethingElse")
-        .assertAccept(false);
+                .withServiceProperty(ServletResolverTestSupport.P_METHODS, "meth")
+                .withMethod("somethingElse")
+                .assertAccept5(false);
     }
 
     @Test
     public void methodPropertyNotSet() {
         new TestCase()
-        .withMethod("somethingElse")
-        .assertAccept(true);
+                .withMethod("somethingElse")
+                .assertAccept3(true);
     }
 
     @Test
     public void testStringStrict() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, "true")
-        .withServiceProperty(ServletResolverTestSupport.P_METHODS, "meth")
-        .withMethod("somethingElse")
-        .assertAccept(false);
+                .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, "true")
+                .withServiceProperty(ServletResolverTestSupport.P_METHODS, "meth")
+                .withMethod("somethingElse")
+                .assertAccept5(false);
     }
 
     @Test
     public void testStringFalseStrict() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, "false")
-        .withServiceProperty(ServletResolverTestSupport.P_METHODS, "meth")
-        .withMethod("somethingElse")
-        .assertAccept(true);
+                .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, "false")
+                .withServiceProperty(ServletResolverTestSupport.P_METHODS, "meth")
+                .withMethod("somethingElse")
+                .assertAccept(true);
     }
 
     @Test
     public void testBooleanFalseStrict() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, false)
-        .withServiceProperty(ServletResolverTestSupport.P_METHODS, "meth")
-        .withMethod("somethingElse")
-        .assertAccept(true);
+                .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, false)
+                .withServiceProperty(ServletResolverTestSupport.P_METHODS, "meth")
+                .withMethod("somethingElse")
+                .assertAccept(true);
     }
 
     @Test
     public void testEmptyExtensionAndSelectorWithEmpty() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
-        .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, V_EMPTY)
-        .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, V_EMPTY)
-        .assertAccept(true);
+                .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
+                .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, V_EMPTY)
+                .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, V_EMPTY)
+                .assertAccept2(true);
     }
 
     @Test
     public void testEmptyExtensionAndSelectorWithSelector() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
-        .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, V_EMPTY)
-        .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, V_EMPTY)
-        .withSelector("someSel")
-        .assertAccept(false);
+                .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
+                .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, V_EMPTY)
+                .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, V_EMPTY)
+                .withSelector("someSel")
+                .assertAccept(false);
     }
 
     @Test
     public void testEmptyExtensionAndSelectorWithExtension() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
-        .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, V_EMPTY)
-        .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, V_EMPTY)
-        .withExtension("someExt")
-        .assertAccept(false);
+                .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
+                .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, V_EMPTY)
+                .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, V_EMPTY)
+                .withExtension("someExt")
+                .assertAccept(false);
     }
 
     @Test
     public void testEmptyExtensionSpecificSelector() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
-        .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, V_EMPTY)
-        .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "someSel")
-        .withSelector("someSel")
-        .assertAccept(true);
+                .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
+                .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, V_EMPTY)
+                .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "someSel")
+                .withSelector("someSel")
+                .assertAccept2(true);
     }
 
     @Test
     public void testEmptySelectorSpecificExtension() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
-        .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, "someExt")
-        .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, V_EMPTY)
-        .withExtension("someExt")
-        .assertAccept(true);
+                .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
+                .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, "someExt")
+                .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, V_EMPTY)
+                .withExtension("someExt")
+                .assertAccept2(true);
     }
 
     @Test(expected = PathBasedServletAcceptor.InvalidPropertyException.class)
     public void testEmptyMethodException() {
         new TestCase()
-        .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
-        .withServiceProperty(ServletResolverTestSupport.P_METHODS, V_EMPTY)
-        .assertAccept(true);
+                .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
+                .withServiceProperty(ServletResolverTestSupport.P_METHODS, V_EMPTY)
+                .assertAccept5(true);
     }
 
     @Test
@@ -312,5 +511,7 @@ public class PathBasedServletAcceptorTest {
         final Servlet s = mock(Servlet.class);
         when(s.getServletConfig()).thenReturn(mock(ServletConfig.class));
         assertTrue(acceptor.accept(null, s));
+
     }
 }
+

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/PathBasedServletAcceptorTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/PathBasedServletAcceptorTest.java
@@ -89,235 +89,69 @@ public class PathBasedServletAcceptorTest {
             return this;
         }
 
+        /**
+         * Consolidated method to handle assertion logic while allowing specific properties to be null.
+         */
+        private void assertAcceptInternal(boolean expected, String... mismtachStubbingArgs) {
+            // Stub the ServiceReference with our service properties
+            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
+            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
+            when(reference.getPropertyKeys()).thenReturn(keys);
+            for (String key : keys) {
+                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
+            }
+
+            // Explicitly set requested properties to null
+            for (String msArgsKey : mismtachStubbingArgs) {
+                when(reference.getProperty(msArgsKey)).thenReturn(null);
+            }
+
+            // Wire the Servlet to our ServiceReference
+            final ServletContext sc = mock(ServletContext.class);
+            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
+            final Servlet servlet = mock(Servlet.class);
+            when(servlet.getServletConfig()).thenReturn(ssc);
+
+            // Setup the request values
+            final RequestPathInfo rpi = mock(RequestPathInfo.class);
+            when(rpi.getExtension()).thenReturn(extension);
+            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
+
+            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
+            when(request.getRequestPathInfo()).thenReturn(rpi);
+            when(request.getMethod()).thenReturn(method);
+
+            // And call the acceptor
+            final boolean actual = acceptor.accept(request, servlet);
+            assertEquals(expected, actual);
+        }
+
         void assertAccept(boolean expected) {
-
-            // Stub the ServiceReference with our service properties
-            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
-            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
-            when(reference.getPropertyKeys()).thenReturn(keys);
-            for (String key : keys) {
-                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
-            }
-
-            // Wire the Servlet to our ServiceReference
-            final ServletContext sc = mock(ServletContext.class);
-            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
-            final Servlet servlet = mock(Servlet.class);
-            when(servlet.getServletConfig()).thenReturn(ssc);
-
-            // Setup the request values
-            final RequestPathInfo rpi = mock(RequestPathInfo.class);
-            when(rpi.getExtension()).thenReturn(extension);
-            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
-
-            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
-            when(request.getRequestPathInfo()).thenReturn(rpi);
-            when(request.getMethod()).thenReturn(method);
-
-            // And call the acceptor
-            final boolean actual = acceptor.accept(request, servlet);
-            assertEquals(expected, actual);
+            assertAcceptInternal(expected, new String[]{});
         }
 
-        void assertAccept2(boolean expected) {
-
-            // Stub the ServiceReference with our service properties
-            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
-            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
-            when(reference.getPropertyKeys()).thenReturn(keys);
-            for (String key : keys) {
-                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
-            }
-
-            when(reference.getProperty("sling.servlet.methods")).thenReturn(null);
-
-            // Wire the Servlet to our ServiceReference
-            final ServletContext sc = mock(ServletContext.class);
-            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
-            final Servlet servlet = mock(Servlet.class);
-            when(servlet.getServletConfig()).thenReturn(ssc);
-
-            // Setup the request values
-            final RequestPathInfo rpi = mock(RequestPathInfo.class);
-            when(rpi.getExtension()).thenReturn(extension);
-            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
-
-            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
-            when(request.getRequestPathInfo()).thenReturn(rpi);
-            when(request.getMethod()).thenReturn(method);
-
-            // And call the acceptor
-            final boolean actual = acceptor.accept(request, servlet);
-            assertEquals(expected, actual);
+        void assertAcceptWithEmptyExtensionAndSelector(boolean expected) {
+            assertAcceptInternal(expected, "sling.servlet.methods");
         }
 
-
-        void assertAccept3(boolean expected) {
-
-            // Stub the ServiceReference with our service properties
-            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
-            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
-            when(reference.getPropertyKeys()).thenReturn(keys);
-            for (String key : keys) {
-                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
-            }
-
-            when(reference.getProperty("sling.servlet.extensions")).thenReturn(null);
-            when(reference.getProperty("sling.servlet.selectors")).thenReturn(null);
-            when(reference.getProperty("sling.servlet.methods")).thenReturn(null);
-
-
-            // Wire the Servlet to our ServiceReference
-            final ServletContext sc = mock(ServletContext.class);
-            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
-            final Servlet servlet = mock(Servlet.class);
-            when(servlet.getServletConfig()).thenReturn(ssc);
-
-            // Setup the request values
-            final RequestPathInfo rpi = mock(RequestPathInfo.class);
-            when(rpi.getExtension()).thenReturn(extension);
-            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
-
-            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
-            when(request.getRequestPathInfo()).thenReturn(rpi);
-            when(request.getMethod()).thenReturn(method);
-
-            // And call the acceptor
-            final boolean actual = acceptor.accept(request, servlet);
-            assertEquals(expected, actual);
+        void assertAcceptWithNoServiceProperty(boolean expected) {
+            assertAcceptInternal(expected, "sling.servlet.extensions", "sling.servlet.selectors", "sling.servlet.methods");
         }
 
-        void assertAccept4(boolean expected) {
-
-            // Stub the ServiceReference with our service properties
-            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
-            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
-            when(reference.getPropertyKeys()).thenReturn(keys);
-            for (String key : keys) {
-                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
-            }
-
-            when(reference.getProperty("sling.servlet.extensions")).thenReturn(null);
-            when(reference.getProperty("sling.servlet.methods")).thenReturn(null);
-
-
-            // Wire the Servlet to our ServiceReference
-            final ServletContext sc = mock(ServletContext.class);
-            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
-            final Servlet servlet = mock(Servlet.class);
-            when(servlet.getServletConfig()).thenReturn(ssc);
-
-            // Setup the request values
-            final RequestPathInfo rpi = mock(RequestPathInfo.class);
-            when(rpi.getExtension()).thenReturn(extension);
-            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
-
-            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
-            when(request.getRequestPathInfo()).thenReturn(rpi);
-            when(request.getMethod()).thenReturn(method);
-
-            // And call the acceptor
-            final boolean actual = acceptor.accept(request, servlet);
-            assertEquals(expected, actual);
+        void assertAcceptWithSelectorMatch(boolean expected) {
+            assertAcceptInternal(expected, "sling.servlet.extensions", "sling.servlet.methods");
         }
 
-        void assertAccept5(boolean expected) {
-
-            // Stub the ServiceReference with our service properties
-            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
-            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
-            when(reference.getPropertyKeys()).thenReturn(keys);
-            for (String key : keys) {
-                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
-            }
-
-            when(reference.getProperty("sling.servlet.extensions")).thenReturn(null);
-            when(reference.getProperty("sling.servlet.selectors")).thenReturn(null);
-
-            // Wire the Servlet to our ServiceReference
-            final ServletContext sc = mock(ServletContext.class);
-            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
-            final Servlet servlet = mock(Servlet.class);
-            when(servlet.getServletConfig()).thenReturn(ssc);
-
-            // Setup the request values
-            final RequestPathInfo rpi = mock(RequestPathInfo.class);
-            when(rpi.getExtension()).thenReturn(extension);
-            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
-
-            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
-            when(request.getRequestPathInfo()).thenReturn(rpi);
-            when(request.getMethod()).thenReturn(method);
-
-            // And call the acceptor
-            final boolean actual = acceptor.accept(request, servlet);
-            assertEquals(expected, actual);
+        void assertAcceptWithMethodMismatch(boolean expected) {
+            assertAcceptInternal(expected, "sling.servlet.extensions", "sling.servlet.selectors");
         }
 
-        void assertAccept6(boolean expected) {
-
-            // Stub the ServiceReference with our service properties
-            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
-            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
-            when(reference.getPropertyKeys()).thenReturn(keys);
-            for (String key : keys) {
-                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
-            }
-
-            when(reference.getProperty("sling.servlet.selectors")).thenReturn(null);
-            when(reference.getProperty("sling.servlet.methods")).thenReturn(null);
-
-
-            // Wire the Servlet to our ServiceReference
-            final ServletContext sc = mock(ServletContext.class);
-            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
-            final Servlet servlet = mock(Servlet.class);
-            when(servlet.getServletConfig()).thenReturn(ssc);
-
-            // Setup the request values
-            final RequestPathInfo rpi = mock(RequestPathInfo.class);
-            when(rpi.getExtension()).thenReturn(extension);
-            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
-
-            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
-            when(request.getRequestPathInfo()).thenReturn(rpi);
-            when(request.getMethod()).thenReturn(method);
-
-            // And call the acceptor
-            final boolean actual = acceptor.accept(request, servlet);
-            assertEquals(expected, actual);
+        void assertAcceptWithExtensionMatch(boolean expected) {
+            assertAcceptInternal(expected, "sling.servlet.selectors", "sling.servlet.methods");
         }
 
-        void assertAccept7(boolean expected) {
-
-            // Stub the ServiceReference with our service properties
-            @SuppressWarnings("unchecked") final ServiceReference<Servlet> reference = mock(ServiceReference.class);
-            final String[] keys = Collections.list(serviceProperties.keys()).toArray(STRING_ARRAY);
-            when(reference.getPropertyKeys()).thenReturn(keys);
-            for (String key : keys) {
-                when(reference.getProperty(key)).thenReturn(serviceProperties.get(key));
-            }
-
-            when(reference.getProperty("sling.servlet.extensions")).thenReturn(null);
-
-            // Wire the Servlet to our ServiceReference
-            final ServletContext sc = mock(ServletContext.class);
-            final SlingServletConfig ssc = new SlingServletConfig(sc, reference, "42");
-            final Servlet servlet = mock(Servlet.class);
-            when(servlet.getServletConfig()).thenReturn(ssc);
-
-            // Setup the request values
-            final RequestPathInfo rpi = mock(RequestPathInfo.class);
-            when(rpi.getExtension()).thenReturn(extension);
-            when(rpi.getSelectors()).thenReturn(selectors.toArray(STRING_ARRAY));
-
-            final SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
-            when(request.getRequestPathInfo()).thenReturn(rpi);
-            when(request.getMethod()).thenReturn(method);
-
-            // And call the acceptor
-            final boolean actual = acceptor.accept(request, servlet);
-            assertEquals(expected, actual);
+        void assertAcceptWithExtensionUnset(boolean expected) {
+            assertAcceptInternal(expected, "sling.servlet.extensions");
         }
     }
 
@@ -350,14 +184,14 @@ public class PathBasedServletAcceptorTest {
                 // test various ways of setting multiple properties
                 .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, (Object) new String[]{"one", "two"})
                 .withExtension("one")
-                .assertAccept6(true);
+                .assertAcceptWithExtensionMatch(true);
     }
 
     @Test
     public void extensionPropertyNotSet() {
         new TestCase()
                 .withExtension("somethingElse")
-                .assertAccept3(true);
+                .assertAcceptWithNoServiceProperty(true);
     }
 
     @Test
@@ -373,7 +207,7 @@ public class PathBasedServletAcceptorTest {
         new TestCase()
                 .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "sel")
                 .withSelector("sel")
-                .assertAccept4(true);
+                .assertAcceptWithSelectorMatch(true);
     }
 
     @Test
@@ -381,7 +215,7 @@ public class PathBasedServletAcceptorTest {
         new TestCase()
                 .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "one", "two", "three")
                 .withSelectors("three", "and", "somethingElse")
-                .assertAccept4(true);
+                .assertAcceptWithSelectorMatch(true);
     }
 
     @Test
@@ -389,7 +223,7 @@ public class PathBasedServletAcceptorTest {
         new TestCase()
                 .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "one", "two", "three")
                 .withExtension("three")
-                .assertAccept7(false);
+                .assertAcceptWithExtensionUnset(false);
     }
 
     @Test
@@ -397,14 +231,14 @@ public class PathBasedServletAcceptorTest {
         new TestCase()
                 .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "one", "two", "42")
                 .withSelectors("42")
-                .assertAccept4(true);
+                .assertAcceptWithSelectorMatch(true);
     }
 
     @Test
     public void selectorPropertyNotSet() {
         new TestCase()
                 .withSelector("somethingElse")
-                .assertAccept3(true);
+                .assertAcceptWithNoServiceProperty(true);
     }
 
     @Test
@@ -412,14 +246,14 @@ public class PathBasedServletAcceptorTest {
         new TestCase()
                 .withServiceProperty(ServletResolverTestSupport.P_METHODS, "meth")
                 .withMethod("somethingElse")
-                .assertAccept5(false);
+                .assertAcceptWithMethodMismatch(false);
     }
 
     @Test
     public void methodPropertyNotSet() {
         new TestCase()
                 .withMethod("somethingElse")
-                .assertAccept3(true);
+                .assertAcceptWithNoServiceProperty(true);
     }
 
     @Test
@@ -428,7 +262,7 @@ public class PathBasedServletAcceptorTest {
                 .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, "true")
                 .withServiceProperty(ServletResolverTestSupport.P_METHODS, "meth")
                 .withMethod("somethingElse")
-                .assertAccept5(false);
+                .assertAcceptWithMethodMismatch(false);
     }
 
     @Test
@@ -455,7 +289,7 @@ public class PathBasedServletAcceptorTest {
                 .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
                 .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, V_EMPTY)
                 .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, V_EMPTY)
-                .assertAccept2(true);
+                .assertAcceptWithEmptyExtensionAndSelector(true);
     }
 
     @Test
@@ -485,7 +319,7 @@ public class PathBasedServletAcceptorTest {
                 .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, V_EMPTY)
                 .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, "someSel")
                 .withSelector("someSel")
-                .assertAccept2(true);
+                .assertAcceptWithEmptyExtensionAndSelector(true);
     }
 
     @Test
@@ -495,7 +329,7 @@ public class PathBasedServletAcceptorTest {
                 .withServiceProperty(ServletResolverTestSupport.P_EXTENSIONS, "someExt")
                 .withServiceProperty(ServletResolverTestSupport.P_SELECTORS, V_EMPTY)
                 .withExtension("someExt")
-                .assertAccept2(true);
+                .assertAcceptWithEmptyExtensionAndSelector(true);
     }
 
     @Test(expected = PathBasedServletAcceptor.InvalidPropertyException.class)
@@ -503,7 +337,7 @@ public class PathBasedServletAcceptorTest {
         new TestCase()
                 .withServiceProperty(ServletResolverTestSupport.P_STRICT_PATHS, true)
                 .withServiceProperty(ServletResolverTestSupport.P_METHODS, V_EMPTY)
-                .assertAccept5(true);
+                .assertAcceptWithMethodMismatch(true);
     }
 
     @Test
@@ -514,4 +348,3 @@ public class PathBasedServletAcceptorTest {
 
     }
 }
-


### PR DESCRIPTION
We are researchers and analyzed the test doubles (mocks) in the test code of the project. In our analysis of the project, we observed that

1. In the test **`extensionMatchOneInN`**, the `getProperty` method is executed with arguments "sling.servlet.selectors" and "sling.servlet.methods" in the `assertAccept` method, but these arguments were not stubbed, leading to mismatched stubbings.

2. In the test **`extensionPropertyNotSet`**, the `getProperty` method is executed with arguments "sling.servlet.extensions", "sling.servlet.selectors", and "sling.servlet.methods" in the `assertAccept` method, but these arguments were not stubbed, leading to mismatched stubbings.

3. In the test **`selectorOneMatchesOne`**, the `getProperty` method is executed with arguments "sling.servlet.extensions" and "sling.servlet.methods" in the `assertAccept` method, but these arguments were not stubbed, leading to mismatched stubbings.

4. In the test **`selectorOneFromNInN`**, the `getProperty` method is executed with arguments "sling.servlet.extensions" and "sling.servlet.methods" in the `assertAccept` method, but these arguments were not stubbed, leading to mismatched stubbings.

5. In the test **`selectorZeroInN`**, the `getProperty` method is executed with the argument "sling.servlet.extensions" in the `assertAccept` method, but it was not stubbed, leading to mismatched stubbings.

6. In the test **`selectorOneInN`**, the `getProperty` method is executed with arguments "sling.servlet.extensions" and "sling.servlet.methods" in the `assertAccept` method, but these arguments were not stubbed, leading to mismatched stubbings.

7. In the test **`selectorPropertyNotSet`**, the `getProperty` method is executed with arguments "sling.servlet.extensions", "sling.servlet.selectors", and "sling.servlet.methods" in the `assertAccept` method, but these arguments were not stubbed, leading to mismatched stubbings.

8. In the test **`methodNoMatch`**, the `getProperty` method is executed with arguments "sling.servlet.extensions" and "sling.servlet.selectors" in the `assertAccept` method, but these arguments were not stubbed, leading to mismatched stubbings.

9. In the test **`methodPropertyNotSet`**, the `getProperty` method is executed with arguments "sling.servlet.extensions" and "sling.servlet.selectors" in the `assertAccept` method, but these arguments were not stubbed, leading to mismatched stubbings.

10. In the test **`testStringStrictIn`**, the `getProperty` method is executed with arguments "sling.servlet.extensions" and "sling.servlet.selectors" in the `assertAccept` method, but these arguments were not stubbed, leading to mismatched stubbings.

11. In the test **`testEmptyExtensionAndSelectorWithEmpty`**, the `getProperty` method is executed with the argument "sling.servlet.methods" in the `assertAccept` method, but it was not stubbed, resulting in mismatched stubbings.

12.  In the test **`testEmptyExtensionSpecificSelector`**, the `getProperty` method is executed with the argument "sling.servlet.methods" in the `assertAccept` method, but it was not stubbed, leading to mismatched stubbings.

13. In the test **`testEmptySelectorSpecificExtension`**, the `getProperty` method is executed with the argument "sling.servlet.methods" in the `assertAccept` method, but it was not stubbed, leading to mismatched stubbings.

14. In the test **`testEmptyMethodException`**, the `getProperty` method is executed with arguments "sling.servlet.extensions" and "sling.servlet.selectors" in the `assertAccept` method, but it was not stubbed, leading to mismatched stubbings.

Mismatched stubbing occurs when a mocked method is stubbed with specific arguments in a test but later invoked with different arguments in the code, potentially causing unexpected behavior. Mockito recommends addressing these issues, (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

We propose a solution below to resolve the mismatch stubbings.