### PR TITLE
Resolve 1 mismatch stubbing in ServletMounterTest.java

### DIFF
--- a/src/test/java/org/apache/sling/servlets/resolver/internal/resource/ServletMounterTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/resource/ServletMounterTest.java
@@ -73,8 +73,8 @@ public class ServletMounterTest {
         final ServiceReference<Servlet> msr = Mockito.mock(ServiceReference.class);
         Mockito.when(msr.getProperty(ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES))
             .thenReturn("sample");
-        Mockito.when(msr.getProperty(ServletResolverConstants.SLING_SERVLET_METHODS))
-            .thenReturn("GET");
+        Mockito.when(msr.getProperty("service.ranking"))
+            .thenReturn(null);
 
         Method createServiceProperties = ServletMounter.class.getDeclaredMethod("createServiceProperties",
                 ServiceReference.class, String.class);


### PR DESCRIPTION
We are researchers and analyzed the test doubles (mocks) in the test code of the project. In our analysis of the project, we observed that

1 stubbing which stubbed `getProperty` method is created in `ServletMounterTest.testCreateServiceProperties`, was stubbed with argument "sling.servlet.methods", but in actual execution, it was called with argument "service.ranking", resulting in a mismatched stubbing.

Mismatched stubbing occurs when a mocked method is stubbed with specific arguments in a test but later invoked with different arguments in the code, potentially causing unexpected behavior. Mockito recommends addressing these issues, (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

We propose a solution below to resolve the mismatch stubbing.